### PR TITLE
fix: Correction des problèmes de contraste sur les pages de livres

### DIFF
--- a/src/app/ressources/meilleurs-livres/digital-ai/ai-superpowers/page.tsx
+++ b/src/app/ressources/meilleurs-livres/digital-ai/ai-superpowers/page.tsx
@@ -104,13 +104,13 @@ export default function AISuperPowersPage() {
             <span className="inline-block bg-purple-500/20 text-purple-300 font-semibold rounded-full px-4 py-2 text-sm shadow-md backdrop-blur mb-2">
               Digital & AI Sales
             </span>
-            <h1 className="text-4xl md:text-6xl font-bold text-white mb-4 drop-shadow-lg">
+            <h1 className="text-4xl md:text-6xl font-bold text-primary-title mb-4 drop-shadow-lg">
               AI Superpowers
             </h1>
-            <p className="text-xl text-purple-300 font-semibold mb-2">
-              Kai-Fu Lee <span className="text-white/60 font-normal">— 2018</span>
+            <p className="text-xl text-primary-secondary font-semibold mb-2">
+              Kai-Fu Lee <span className="text-primary-secondary/70 font-normal">— 2018</span>
             </p>
-            <p className="text-lg text-white/90 italic mb-6 max-w-2xl mx-auto">
+            <p className="text-lg text-primary-secondary/90 italic mb-6 max-w-2xl mx-auto">
               Anticiper l'évolution des métiers commerciaux à l'ère de l'IA
             </p>
             
@@ -119,7 +119,7 @@ export default function AISuperPowersPage() {
               <span className="bg-orange-soft/20 text-orange-soft px-3 py-1 rounded-full text-sm font-medium">
                 Intermédiaire
               </span>
-              <span className="bg-blue-ink/20 text-white px-3 py-1 rounded-full text-sm font-medium">
+              <span className="bg-blue-ink/20 text-primary-secondary px-3 py-1 rounded-full text-sm font-medium">
                 6h de lecture
               </span>
               <div className="flex items-center bg-yellow-400/20 text-yellow-600 px-3 py-1 rounded-full text-sm font-medium">

--- a/src/app/ressources/meilleurs-livres/digital-ai/page.tsx
+++ b/src/app/ressources/meilleurs-livres/digital-ai/page.tsx
@@ -174,10 +174,10 @@ export default function DigitalAISalesPage() {
             >
               <span aria-hidden="true">{category.icon}</span> Catégorie
             </span>
-            <h1 id="hero-title" className="text-4xl md:text-5xl font-bold text-white mb-4 drop-shadow-lg">
+            <h1 id="hero-title" className="text-4xl md:text-5xl font-bold text-primary-title mb-4 drop-shadow-lg">
               {category.title}
             </h1>
-            <p className="text-lg md:text-xl text-white/80 mb-6 leading-relaxed">
+            <p className="text-lg md:text-xl text-primary-secondary/90 mb-6 leading-relaxed">
               {category.description}
             </p>
             
@@ -202,7 +202,7 @@ export default function DigitalAISalesPage() {
                     L'IA transforme déjà la vente
                   </h2>
                 </div>
-                <p className="text-white/90 leading-relaxed mb-4">
+                <p className="text-primary-secondary/90 leading-relaxed mb-4">
                   Prospection automatisée, scoring prédictif, analyse conversationnelle... 
                   L'intelligence artificielle révolutionne chaque étape du processus commercial. 
                   Ces 5 livres vous donnent les clés pour comprendre, anticiper et maîtriser cette transformation.
@@ -216,7 +216,7 @@ export default function DigitalAISalesPage() {
                     </div>
                     <span className="text-cyan-300 font-semibold">Vision Laurent Serre</span>
                   </div>
-                  <p className="text-white/90 text-sm italic">
+                  <p className="text-primary-secondary/90 text-sm italic">
                     "Après 20 ans d'accompagnement PME, je vois l'IA comme le plus grand levier de transformation commerciale depuis l'arrivée d'Internet. 
                     Ces livres ne sont pas de la théorie : ils décrivent des réalités que mes clients vivent déjà. 
                     L'enjeu n'est plus de savoir si l'IA va transformer votre métier, mais comment vous allez la maîtriser."
@@ -227,15 +227,15 @@ export default function DigitalAISalesPage() {
                 <div className="grid grid-cols-3 gap-4 mt-6 pt-4 border-t border-cyan-400/20">
                   <div className="text-center">
                     <div className="text-2xl font-bold text-cyan-400">85%</div>
-                    <div className="text-xs text-white/70">des entreprises utilisent l'IA</div>
+                    <div className="text-xs text-primary-secondary/70">des entreprises utilisent l'IA</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-cyan-400">3x</div>
-                    <div className="text-xs text-white/70">plus de leads qualifiés</div>
+                    <div className="text-xs text-primary-secondary/70">plus de leads qualifiés</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-cyan-400">60%</div>
-                    <div className="text-xs text-white/70">de gain de temps</div>
+                    <div className="text-xs text-primary-secondary/70">de gain de temps</div>
                   </div>
                 </div>
               </div>
@@ -296,10 +296,10 @@ export default function DigitalAISalesPage() {
                 <AIIcon type="circuit" size="sm" className="inline mr-2" />
                 Technologies émergentes
               </span>
-              <h3 className="text-2xl font-bold text-white mb-4">
+              <h3 className="text-2xl font-bold text-primary-title mb-4">
                 Les innovations qui transforment la vente
               </h3>
-              <p className="text-white/80 leading-relaxed max-w-3xl mx-auto">
+              <p className="text-primary-secondary/90 leading-relaxed max-w-3xl mx-auto">
                 Découvrez les technologies d'IA qui révolutionnent déjà le métier commercial et préparez-vous aux évolutions futures
               </p>
             </div>

--- a/src/app/ressources/meilleurs-livres/mindset-performance/7-habitudes-gens-efficaces/page.tsx
+++ b/src/app/ressources/meilleurs-livres/mindset-performance/7-habitudes-gens-efficaces/page.tsx
@@ -5,6 +5,7 @@ import AnimatedSection from '@/components/ui/AnimatedSection';
 import BookCard from '@/components/ui/BookCard';
 import CategoryBreadcrumb from '@/components/ui/CategoryBreadcrumb';
 import ParticleBackground from '@/components/ui/ParticleBackground';
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer';
 import { categoryBreadcrumbSuggestions } from '@/utils/cross-category-suggestions';
 import React from 'react';
 
@@ -75,25 +76,25 @@ export default function SevenHabitsPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection animation="fade-in" delay={0}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <div className="flex flex-col lg:flex-row gap-8 items-start">
+            <div className="flex flex-col gap-8 items-start">
               {/* Informations du livre */}
-              <div className="flex-1">
+              <div className="w-full">
                 <div className="flex items-center gap-2 mb-4">
                   <span className="bg-orange-soft/20 text-orange-soft px-3 py-1 rounded-full text-sm font-medium">
                     🧠 Mindset & Performance
                   </span>
-                  <span className="bg-white/20 text-white px-3 py-1 rounded-full text-sm">
+                  <span className="bg-white/20 text-primary-secondary px-3 py-1 rounded-full text-sm">
                     {bookData.year}
                   </span>
                 </div>
                 
-                <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">
+                <h1 className="text-3xl md:text-4xl font-bold text-primary-title mb-2">
                   {bookData.title}
                 </h1>
-                <p className="text-xl text-orange-300 mb-4">
+                <p className="text-xl text-primary-secondary mb-4">
                   par {bookData.author}
                 </p>
-                <p className="text-lg text-white/80 mb-6 leading-relaxed">
+                <p className="text-lg text-primary-secondary/90 mb-6 leading-relaxed">
                   {bookData.tagline}
                 </p>
                 
@@ -101,33 +102,23 @@ export default function SevenHabitsPage() {
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
                   <div className="text-center">
                     <div className="text-2xl font-bold text-orange-soft">{bookData.rating}/5</div>
-                    <div className="text-xs text-white/70">Note Laurent Serre</div>
+                    <div className="text-xs text-primary-secondary">Note Laurent Serre</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-orange-soft">{bookData.difficulty}</div>
-                    <div className="text-xs text-white/70">Difficulté</div>
+                    <div className="text-xs text-primary-secondary">Difficulté</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-orange-soft">{bookData.readingTime}</div>
-                    <div className="text-xs text-white/70">Lecture</div>
+                    <div className="text-xs text-primary-secondary">Lecture</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-orange-soft">★★★</div>
-                    <div className="text-xs text-white/70">Impact commercial</div>
+                    <div className="text-xs text-primary-secondary">Impact commercial</div>
                   </div>
                 </div>
               </div>
-              
-              {/* BookCard en version featured */}
-              <div className="lg:w-80">
-                <BookCard 
-                  book={bookData} 
-                  variant="featured"
-                  showRating={true}
-                  showDifficulty={true}
-                  showReadingTime={true}
-                />
-              </div>
+
             </div>
           </div>
         </AnimatedSection>
@@ -137,14 +128,15 @@ export default function SevenHabitsPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={100}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-orange-soft">📖</span>
               Résumé détaillé
             </h2>
-            <div className="prose prose-lg prose-invert max-w-none">
-              <p className="text-white/90 leading-relaxed mb-6">
-                {bookData.detailedSummary}
-              </p>
+            <div className="prose prose-lg max-w-none">
+              <MarkdownRenderer 
+                content={bookData.detailedSummary} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -154,7 +146,7 @@ export default function SevenHabitsPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={200}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-orange-soft">🎯</span>
               Les 7 habitudes expliquées
             </h2>
@@ -162,10 +154,10 @@ export default function SevenHabitsPage() {
               {Array.isArray(bookData.keyPoints) && bookData.keyPoints.length > 0 ? bookData.keyPoints.map((point, index) => (
                 <div key={index} className="flex items-start gap-3 p-4 bg-white/5 rounded-lg border border-orange-soft/10">
                   <span className="text-orange-soft font-bold text-lg">{index + 1}.</span>
-                  <p className="text-white/90 leading-relaxed">{point}</p>
+                  <p className="text-primary-secondary leading-relaxed">{point}</p>
                 </div>
               )) : (
-                <p className="text-white/70">Points clés en cours de rédaction...</p>
+                <p className="text-primary-secondary/70">Points clés en cours de rédaction...</p>
               )}
             </div>
           </div>
@@ -181,14 +173,15 @@ export default function SevenHabitsPage() {
                 <span className="text-white font-bold">LS</span>
               </div>
               <div>
-                <h2 className="text-2xl font-bold text-white">Conseils terrain Laurent Serre</h2>
-                <p className="text-orange-300">20 ans d'expérience en développement commercial PME</p>
+                <h2 className="text-2xl font-bold text-primary-title">Conseils terrain Laurent Serre</h2>
+                <p className="text-primary-secondary">20 ans d'expérience en développement commercial PME</p>
               </div>
             </div>
             <div className="bg-white/10 rounded-lg p-6 border border-orange-soft/20">
-              <p className="text-white/90 leading-relaxed whitespace-pre-line">
-                {bookData.terrainAdvice}
-              </p>
+              <MarkdownRenderer 
+                content={bookData.terrainAdvice} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -198,7 +191,7 @@ export default function SevenHabitsPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={400}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-orange-soft">👥</span>
               Pour qui ce livre ?
             </h2>
@@ -206,10 +199,10 @@ export default function SevenHabitsPage() {
               {Array.isArray(bookData.targetProfiles) && bookData.targetProfiles.length > 0 ? bookData.targetProfiles.map((profile, index) => (
                 <div key={index} className="flex items-center gap-3 p-4 bg-white/5 rounded-lg border border-orange-soft/10">
                   <span className="text-orange-soft">✓</span>
-                  <span className="text-white/90">{profile}</span>
+                  <span className="text-primary-secondary">{profile}</span>
                 </div>
               )) : (
-                <p className="text-white/70">Profils cibles en cours de définition...</p>
+                <p className="text-primary-secondary/70">Profils cibles en cours de définition...</p>
               )}
             </div>
           </div>
@@ -220,11 +213,11 @@ export default function SevenHabitsPage() {
       <section className="max-w-6xl mx-auto mb-12 px-4">
         <AnimatedSection delay={500}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-orange-soft">📚</span>
               Livres complémentaires recommandés
             </h2>
-            <p className="text-white/80 mb-4">
+            <p className="text-primary-secondary mb-4">
               Pour approfondir votre développement personnel et commercial, découvrez ces autres références essentielles.
             </p>
             <div className="flex flex-wrap gap-2">

--- a/src/app/ressources/meilleurs-livres/mindset-performance/atomic-habits/page.tsx
+++ b/src/app/ressources/meilleurs-livres/mindset-performance/atomic-habits/page.tsx
@@ -5,6 +5,7 @@ import AnimatedSection from '@/components/ui/AnimatedSection';
 import BookCard from '@/components/ui/BookCard';
 import CategoryBreadcrumb from '@/components/ui/CategoryBreadcrumb';
 import ParticleBackground from '@/components/ui/ParticleBackground';
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer';
 import { categoryBreadcrumbSuggestions } from '@/utils/cross-category-suggestions';
 import React from 'react';
 
@@ -75,25 +76,25 @@ export default function AtomicHabitsPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection animation="fade-in" delay={0}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <div className="flex flex-col lg:flex-row gap-8 items-start">
+            <div className="flex flex-col gap-8 items-start">
               {/* Informations du livre */}
-              <div className="flex-1">
+              <div className="w-full">
                 <div className="flex items-center gap-2 mb-4">
                   <span className="bg-orange-soft/20 text-orange-soft px-3 py-1 rounded-full text-sm font-medium">
                     🧠 Mindset & Performance
                   </span>
-                  <span className="bg-white/20 text-white px-3 py-1 rounded-full text-sm">
+                  <span className="bg-white/20 text-primary-secondary px-3 py-1 rounded-full text-sm">
                     {bookData.year}
                   </span>
                 </div>
                 
-                <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">
+                <h1 className="text-3xl md:text-4xl font-bold text-primary-title mb-2">
                   {bookData.title}
                 </h1>
-                <p className="text-xl text-orange-300 mb-4">
+                <p className="text-xl text-primary-secondary mb-4">
                   par {bookData.author}
                 </p>
-                <p className="text-lg text-white/80 mb-6 leading-relaxed">
+                <p className="text-lg text-primary-secondary/90 mb-6 leading-relaxed">
                   {bookData.tagline}
                 </p>
                 
@@ -101,33 +102,24 @@ export default function AtomicHabitsPage() {
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
                   <div className="text-center">
                     <div className="text-2xl font-bold text-orange-soft">{bookData.rating}/5</div>
-                    <div className="text-xs text-white/70">Note Laurent Serre</div>
+                    <div className="text-xs text-primary-secondary">Note Laurent Serre</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-orange-soft">{bookData.difficulty}</div>
-                    <div className="text-xs text-white/70">Difficulté</div>
+                    <div className="text-xs text-primary-secondary">Difficulté</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-orange-soft">{bookData.readingTime}</div>
-                    <div className="text-xs text-white/70">Lecture</div>
+                    <div className="text-xs text-primary-secondary">Lecture</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-orange-soft">★★★</div>
-                    <div className="text-xs text-white/70">Impact commercial</div>
+                    <div className="text-xs text-primary-secondary">Impact commercial</div>
                   </div>
                 </div>
               </div>
               
-              {/* BookCard en version featured */}
-              <div className="lg:w-80">
-                <BookCard 
-                  book={bookData} 
-                  variant="featured"
-                  showRating={true}
-                  showDifficulty={true}
-                  showReadingTime={true}
-                />
-              </div>
+
             </div>
           </div>
         </AnimatedSection>
@@ -137,14 +129,15 @@ export default function AtomicHabitsPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={100}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-orange-soft">📖</span>
               Résumé détaillé
             </h2>
-            <div className="prose prose-lg prose-invert max-w-none">
-              <p className="text-white/90 leading-relaxed mb-6">
-                {bookData.detailedSummary}
-              </p>
+            <div className="prose prose-lg max-w-none">
+              <MarkdownRenderer 
+                content={bookData.detailedSummary} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -154,7 +147,7 @@ export default function AtomicHabitsPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={200}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-orange-soft">🎯</span>
               Points clés à retenir
             </h2>
@@ -162,10 +155,10 @@ export default function AtomicHabitsPage() {
               {Array.isArray(bookData.keyPoints) && bookData.keyPoints.length > 0 ? bookData.keyPoints.map((point, index) => (
                 <div key={index} className="flex items-start gap-3 p-4 bg-white/5 rounded-lg border border-orange-soft/10">
                   <span className="text-orange-soft font-bold text-lg">{index + 1}.</span>
-                  <p className="text-white/90 leading-relaxed">{point}</p>
+                  <p className="text-primary-secondary leading-relaxed">{point}</p>
                 </div>
               )) : (
-                <p className="text-white/70">Points clés en cours de rédaction...</p>
+                <p className="text-primary-secondary/70">Points clés en cours de rédaction...</p>
               )}
             </div>
           </div>
@@ -181,14 +174,15 @@ export default function AtomicHabitsPage() {
                 <span className="text-white font-bold">LS</span>
               </div>
               <div>
-                <h2 className="text-2xl font-bold text-white">Conseils terrain Laurent Serre</h2>
-                <p className="text-orange-300">20 ans d'expérience en développement commercial PME</p>
+                <h2 className="text-2xl font-bold text-primary-title">Conseils terrain Laurent Serre</h2>
+                <p className="text-primary-secondary">20 ans d'expérience en développement commercial PME</p>
               </div>
             </div>
             <div className="bg-white/10 rounded-lg p-6 border border-orange-soft/20">
-              <p className="text-white/90 leading-relaxed whitespace-pre-line">
-                {bookData.terrainAdvice}
-              </p>
+              <MarkdownRenderer 
+                content={bookData.terrainAdvice} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -198,7 +192,7 @@ export default function AtomicHabitsPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={400}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-orange-soft">👥</span>
               Pour qui ce livre ?
             </h2>
@@ -206,10 +200,10 @@ export default function AtomicHabitsPage() {
               {Array.isArray(bookData.targetProfiles) && bookData.targetProfiles.length > 0 ? bookData.targetProfiles.map((profile, index) => (
                 <div key={index} className="flex items-center gap-3 p-4 bg-white/5 rounded-lg border border-orange-soft/10">
                   <span className="text-orange-soft">✓</span>
-                  <span className="text-white/90">{profile}</span>
+                  <span className="text-primary-secondary">{profile}</span>
                 </div>
               )) : (
-                <p className="text-white/70">Profils cibles en cours de définition...</p>
+                <p className="text-primary-secondary/70">Profils cibles en cours de définition...</p>
               )}
             </div>
           </div>
@@ -220,11 +214,11 @@ export default function AtomicHabitsPage() {
       <section className="max-w-6xl mx-auto mb-12 px-4">
         <AnimatedSection delay={500}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-orange-soft">📚</span>
               Livres complémentaires recommandés
             </h2>
-            <p className="text-white/80 mb-4">
+            <p className="text-primary-secondary mb-4">
               Pour approfondir votre développement personnel et commercial, découvrez ces autres références essentielles.
             </p>
             <div className="flex flex-wrap gap-2">

--- a/src/app/ressources/meilleurs-livres/mindset-performance/cant-hurt-me/page.tsx
+++ b/src/app/ressources/meilleurs-livres/mindset-performance/cant-hurt-me/page.tsx
@@ -5,6 +5,7 @@ import AnimatedSection from '@/components/ui/AnimatedSection';
 import BookCard from '@/components/ui/BookCard';
 import CategoryBreadcrumb from '@/components/ui/CategoryBreadcrumb';
 import ParticleBackground from '@/components/ui/ParticleBackground';
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer';
 import { categoryBreadcrumbSuggestions } from '@/utils/cross-category-suggestions';
 import React from 'react';
 
@@ -78,25 +79,25 @@ export default function CantHurtMePage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection animation="fade-in" delay={0}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-red-500/20">
-            <div className="flex flex-col lg:flex-row gap-8 items-start">
+            <div className="flex flex-col gap-8 items-start">
               {/* Informations du livre */}
-              <div className="flex-1">
+              <div className="w-full">
                 <div className="flex items-center gap-2 mb-4">
                   <span className="bg-red-500/20 text-red-400 px-3 py-1 rounded-full text-sm font-medium">
                     🧠 Mindset & Performance
                   </span>
-                  <span className="bg-white/20 text-white px-3 py-1 rounded-full text-sm">
+                  <span className="bg-white/20 text-primary-secondary px-3 py-1 rounded-full text-sm">
                     {bookData.year}
                   </span>
                 </div>
                 
-                <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">
+                <h1 className="text-3xl md:text-4xl font-bold text-primary-title mb-2">
                   {bookData.title}
                 </h1>
-                <p className="text-xl text-red-300 mb-4">
+                <p className="text-xl text-primary-secondary mb-4">
                   par {bookData.author}
                 </p>
-                <p className="text-lg text-white/80 mb-6 leading-relaxed">
+                <p className="text-lg text-primary-secondary/90 mb-6 leading-relaxed">
                   {bookData.tagline}
                 </p>
                 
@@ -104,33 +105,24 @@ export default function CantHurtMePage() {
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
                   <div className="text-center">
                     <div className="text-2xl font-bold text-red-400">{bookData.rating}/5</div>
-                    <div className="text-xs text-white/70">Note Laurent Serre</div>
+                    <div className="text-xs text-primary-secondary">Note Laurent Serre</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-red-400">{bookData.difficulty}</div>
-                    <div className="text-xs text-white/70">Difficulté</div>
+                    <div className="text-xs text-primary-secondary">Difficulté</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-red-400">{bookData.readingTime}</div>
-                    <div className="text-xs text-white/70">Lecture</div>
+                    <div className="text-xs text-primary-secondary">Lecture</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-red-400">★★★</div>
-                    <div className="text-xs text-white/70">Impact commercial</div>
+                    <div className="text-xs text-primary-secondary">Impact commercial</div>
                   </div>
                 </div>
               </div>
               
-              {/* BookCard en version featured */}
-              <div className="lg:w-80">
-                <BookCard 
-                  book={bookData} 
-                  variant="featured"
-                  showRating={true}
-                  showDifficulty={true}
-                  showReadingTime={true}
-                />
-              </div>
+
             </div>
           </div>
         </AnimatedSection>
@@ -140,14 +132,15 @@ export default function CantHurtMePage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={100}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-red-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-red-400">📖</span>
               Résumé détaillé
             </h2>
-            <div className="prose prose-lg prose-invert max-w-none">
-              <p className="text-white/90 leading-relaxed mb-6">
-                {bookData.detailedSummary}
-              </p>
+            <div className="prose prose-lg max-w-none">
+              <MarkdownRenderer 
+                content={bookData.detailedSummary} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -157,7 +150,7 @@ export default function CantHurtMePage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={200}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-red-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-red-400">🎯</span>
               Points clés à retenir
             </h2>
@@ -165,10 +158,10 @@ export default function CantHurtMePage() {
               {Array.isArray(bookData.keyPoints) && bookData.keyPoints.length > 0 ? bookData.keyPoints.map((point, index) => (
                 <div key={index} className="flex items-start gap-3 p-4 bg-white/5 rounded-lg border border-red-500/10">
                   <span className="text-red-400 font-bold text-lg">{index + 1}.</span>
-                  <p className="text-white/90 leading-relaxed">{point}</p>
+                  <p className="text-primary-secondary leading-relaxed">{point}</p>
                 </div>
               )) : (
-                <p className="text-white/70">Points clés en cours de rédaction...</p>
+                <p className="text-primary-secondary/70">Points clés en cours de rédaction...</p>
               )}
             </div>
           </div>
@@ -184,14 +177,15 @@ export default function CantHurtMePage() {
                 <span className="text-white font-bold">LS</span>
               </div>
               <div>
-                <h2 className="text-2xl font-bold text-white">Conseils terrain Laurent Serre</h2>
-                <p className="text-red-300">20 ans d'expérience en développement commercial PME</p>
+                <h2 className="text-2xl font-bold text-primary-title">Conseils terrain Laurent Serre</h2>
+                <p className="text-primary-secondary">20 ans d'expérience en développement commercial PME</p>
               </div>
             </div>
             <div className="bg-white/10 rounded-lg p-6 border border-red-500/20">
-              <p className="text-white/90 leading-relaxed whitespace-pre-line">
-                {bookData.terrainAdvice}
-              </p>
+              <MarkdownRenderer 
+                content={bookData.terrainAdvice} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -201,7 +195,7 @@ export default function CantHurtMePage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={400}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-red-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-red-400">👥</span>
               Pour qui ce livre ?
             </h2>
@@ -209,10 +203,10 @@ export default function CantHurtMePage() {
               {Array.isArray(bookData.targetProfiles) && bookData.targetProfiles.length > 0 ? bookData.targetProfiles.map((profile, index) => (
                 <div key={index} className="flex items-center gap-3 p-4 bg-white/5 rounded-lg border border-red-500/10">
                   <span className="text-red-400">✓</span>
-                  <span className="text-white/90">{profile}</span>
+                  <span className="text-primary-secondary">{profile}</span>
                 </div>
               )) : (
-                <p className="text-white/70">Profils cibles en cours de définition...</p>
+                <p className="text-primary-secondary/70">Profils cibles en cours de définition...</p>
               )}
             </div>
           </div>
@@ -223,11 +217,11 @@ export default function CantHurtMePage() {
       <section className="max-w-6xl mx-auto mb-12 px-4">
         <AnimatedSection delay={500}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-red-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-red-400">📚</span>
               Livres complémentaires recommandés
             </h2>
-            <p className="text-white/80 mb-4">
+            <p className="text-primary-secondary mb-4">
               Pour approfondir votre développement mental et votre résilience commerciale.
             </p>
             <div className="flex flex-wrap gap-2">

--- a/src/app/ressources/meilleurs-livres/mindset-performance/grit-power-passion-perseverance/page.tsx
+++ b/src/app/ressources/meilleurs-livres/mindset-performance/grit-power-passion-perseverance/page.tsx
@@ -5,6 +5,7 @@ import AnimatedSection from '@/components/ui/AnimatedSection';
 import BookCard from '@/components/ui/BookCard';
 import CategoryBreadcrumb from '@/components/ui/CategoryBreadcrumb';
 import ParticleBackground from '@/components/ui/ParticleBackground';
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer';
 import { categoryBreadcrumbSuggestions } from '@/utils/cross-category-suggestions';
 import React from 'react';
 
@@ -74,25 +75,25 @@ export default function GritPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection animation="fade-in" delay={0}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <div className="flex flex-col lg:flex-row gap-8 items-start">
+            <div className="flex flex-col gap-8 items-start">
               {/* Informations du livre */}
-              <div className="flex-1">
+              <div className="w-full">
                 <div className="flex items-center gap-2 mb-4">
                   <span className="bg-orange-soft/20 text-orange-soft px-3 py-1 rounded-full text-sm font-medium">
                     🧠 Mindset & Performance
                   </span>
-                  <span className="bg-white/20 text-white px-3 py-1 rounded-full text-sm">
+                  <span className="bg-white/20 text-primary-secondary px-3 py-1 rounded-full text-sm">
                     {bookData.year}
                   </span>
                 </div>
                 
-                <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">
+                <h1 className="text-3xl md:text-4xl font-bold text-primary-title mb-2">
                   {bookData.title}
                 </h1>
-                <p className="text-xl text-orange-300 mb-4">
+                <p className="text-xl text-primary-secondary mb-4">
                   par {bookData.author}
                 </p>
-                <p className="text-lg text-white/80 mb-6 leading-relaxed">
+                <p className="text-lg text-primary-secondary/90 mb-6 leading-relaxed">
                   {bookData.tagline}
                 </p>
                 
@@ -100,33 +101,23 @@ export default function GritPage() {
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
                   <div className="text-center">
                     <div className="text-2xl font-bold text-orange-soft">{bookData.rating}/5</div>
-                    <div className="text-xs text-white/70">Note Laurent Serre</div>
+                    <div className="text-xs text-primary-secondary">Note Laurent Serre</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-orange-soft">{bookData.difficulty}</div>
-                    <div className="text-xs text-white/70">Difficulté</div>
+                    <div className="text-xs text-primary-secondary">Difficulté</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-orange-soft">{bookData.readingTime}</div>
-                    <div className="text-xs text-white/70">Lecture</div>
+                    <div className="text-xs text-primary-secondary">Lecture</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-orange-soft">★★★</div>
-                    <div className="text-xs text-white/70">Impact commercial</div>
+                    <div className="text-xs text-primary-secondary">Impact commercial</div>
                   </div>
                 </div>
               </div>
-              
-              {/* BookCard en version featured */}
-              <div className="lg:w-80">
-                <BookCard 
-                  book={bookData} 
-                  variant="featured"
-                  showRating={true}
-                  showDifficulty={true}
-                  showReadingTime={true}
-                />
-              </div>
+
             </div>
           </div>
         </AnimatedSection>
@@ -136,14 +127,15 @@ export default function GritPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={100}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-orange-soft">📖</span>
               Résumé détaillé
             </h2>
-            <div className="prose prose-lg prose-invert max-w-none">
-              <p className="text-white/90 leading-relaxed mb-6">
-                {bookData.detailedSummary}
-              </p>
+            <div className="prose prose-lg max-w-none">
+              <MarkdownRenderer 
+                content={bookData.detailedSummary} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -153,7 +145,7 @@ export default function GritPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={200}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-orange-soft">🎯</span>
               Points clés à retenir
             </h2>
@@ -161,10 +153,10 @@ export default function GritPage() {
               {Array.isArray(bookData.keyPoints) && bookData.keyPoints.length > 0 ? bookData.keyPoints.map((point, index) => (
                 <div key={index} className="flex items-start gap-3 p-4 bg-white/5 rounded-lg border border-orange-soft/10">
                   <span className="text-orange-soft font-bold text-lg">{index + 1}.</span>
-                  <p className="text-white/90 leading-relaxed">{point}</p>
+                  <p className="text-primary-secondary leading-relaxed">{point}</p>
                 </div>
               )) : (
-                <p className="text-white/70">Points clés en cours de rédaction...</p>
+                <p className="text-primary-secondary/70">Points clés en cours de rédaction...</p>
               )}
             </div>
           </div>
@@ -180,14 +172,15 @@ export default function GritPage() {
                 <span className="text-white font-bold">LS</span>
               </div>
               <div>
-                <h2 className="text-2xl font-bold text-white">Conseils terrain Laurent Serre</h2>
-                <p className="text-orange-300">20 ans d'expérience en développement commercial PME</p>
+                <h2 className="text-2xl font-bold text-primary-title">Conseils terrain Laurent Serre</h2>
+                <p className="text-primary-secondary">20 ans d'expérience en développement commercial PME</p>
               </div>
             </div>
             <div className="bg-white/10 rounded-lg p-6 border border-orange-soft/20">
-              <p className="text-white/90 leading-relaxed whitespace-pre-line">
-                {bookData.terrainAdvice}
-              </p>
+              <MarkdownRenderer 
+                content={bookData.terrainAdvice} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -197,7 +190,7 @@ export default function GritPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={400}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-orange-soft">👥</span>
               Pour qui ce livre ?
             </h2>
@@ -205,10 +198,10 @@ export default function GritPage() {
               {Array.isArray(bookData.targetProfiles) && bookData.targetProfiles.length > 0 ? bookData.targetProfiles.map((profile, index) => (
                 <div key={index} className="flex items-center gap-3 p-4 bg-white/5 rounded-lg border border-orange-soft/10">
                   <span className="text-orange-soft">✓</span>
-                  <span className="text-white/90">{profile}</span>
+                  <span className="text-primary-secondary">{profile}</span>
                 </div>
               )) : (
-                <p className="text-white/70">Profils cibles en cours de définition...</p>
+                <p className="text-primary-secondary/70">Profils cibles en cours de définition...</p>
               )}
             </div>
           </div>
@@ -219,11 +212,11 @@ export default function GritPage() {
       <section className="max-w-6xl mx-auto mb-12 px-4">
         <AnimatedSection delay={500}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-orange-soft">📚</span>
               Livres complémentaires recommandés
             </h2>
-            <p className="text-white/80 mb-4">
+            <p className="text-primary-secondary mb-4">
               Pour approfondir votre développement personnel et commercial, découvrez ces autres références essentielles.
             </p>
             <div className="flex flex-wrap gap-2">

--- a/src/app/ressources/meilleurs-livres/mindset-performance/mindset-new-psychology-success/page.tsx
+++ b/src/app/ressources/meilleurs-livres/mindset-performance/mindset-new-psychology-success/page.tsx
@@ -5,6 +5,7 @@ import AnimatedSection from '@/components/ui/AnimatedSection';
 import BookCard from '@/components/ui/BookCard';
 import CategoryBreadcrumb from '@/components/ui/CategoryBreadcrumb';
 import ParticleBackground from '@/components/ui/ParticleBackground';
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer';
 import { categoryBreadcrumbSuggestions } from '@/utils/cross-category-suggestions';
 import React from 'react';
 
@@ -74,25 +75,25 @@ export default function MindsetPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection animation="fade-in" delay={0}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <div className="flex flex-col lg:flex-row gap-8 items-start">
+            <div className="flex flex-col gap-8 items-start">
               {/* Informations du livre */}
-              <div className="flex-1">
+              <div className="w-full">
                 <div className="flex items-center gap-2 mb-4">
                   <span className="bg-orange-soft/20 text-orange-soft px-3 py-1 rounded-full text-sm font-medium">
                     🧠 Mindset & Performance
                   </span>
-                  <span className="bg-white/20 text-white px-3 py-1 rounded-full text-sm">
+                  <span className="bg-white/20 text-primary-secondary px-3 py-1 rounded-full text-sm">
                     {bookData.year}
                   </span>
                 </div>
                 
-                <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">
+                <h1 className="text-3xl md:text-4xl font-bold text-primary-title mb-2">
                   {bookData.title}
                 </h1>
-                <p className="text-xl text-orange-300 mb-4">
+                <p className="text-xl text-primary-secondary mb-4">
                   par {bookData.author}
                 </p>
-                <p className="text-lg text-white/80 mb-6 leading-relaxed">
+                <p className="text-lg text-primary-secondary/90 mb-6 leading-relaxed">
                   {bookData.tagline}
                 </p>
                 
@@ -100,33 +101,23 @@ export default function MindsetPage() {
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
                   <div className="text-center">
                     <div className="text-2xl font-bold text-orange-soft">{bookData.rating}/5</div>
-                    <div className="text-xs text-white/70">Note Laurent Serre</div>
+                    <div className="text-xs text-primary-secondary">Note Laurent Serre</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-orange-soft">{bookData.difficulty}</div>
-                    <div className="text-xs text-white/70">Difficulté</div>
+                    <div className="text-xs text-primary-secondary">Difficulté</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-orange-soft">{bookData.readingTime}</div>
-                    <div className="text-xs text-white/70">Lecture</div>
+                    <div className="text-xs text-primary-secondary">Lecture</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-orange-soft">★★★</div>
-                    <div className="text-xs text-white/70">Impact commercial</div>
+                    <div className="text-xs text-primary-secondary">Impact commercial</div>
                   </div>
                 </div>
               </div>
-              
-              {/* BookCard en version featured */}
-              <div className="lg:w-80">
-                <BookCard 
-                  book={bookData} 
-                  variant="featured"
-                  showRating={true}
-                  showDifficulty={true}
-                  showReadingTime={true}
-                />
-              </div>
+
             </div>
           </div>
         </AnimatedSection>
@@ -136,14 +127,15 @@ export default function MindsetPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={100}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-orange-soft">📖</span>
               Résumé détaillé
             </h2>
-            <div className="prose prose-lg prose-invert max-w-none">
-              <p className="text-white/90 leading-relaxed mb-6">
-                {bookData.detailedSummary}
-              </p>
+            <div className="prose prose-lg max-w-none">
+              <MarkdownRenderer 
+                content={bookData.detailedSummary} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -153,7 +145,7 @@ export default function MindsetPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={200}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-orange-soft">🎯</span>
               Points clés à retenir
             </h2>
@@ -161,10 +153,10 @@ export default function MindsetPage() {
               {Array.isArray(bookData.keyPoints) && bookData.keyPoints.length > 0 ? bookData.keyPoints.map((point, index) => (
                 <div key={index} className="flex items-start gap-3 p-4 bg-white/5 rounded-lg border border-orange-soft/10">
                   <span className="text-orange-soft font-bold text-lg">{index + 1}.</span>
-                  <p className="text-white/90 leading-relaxed">{point}</p>
+                  <p className="text-primary-secondary leading-relaxed">{point}</p>
                 </div>
               )) : (
-                <p className="text-white/70">Points clés en cours de rédaction...</p>
+                <p className="text-primary-secondary/70">Points clés en cours de rédaction...</p>
               )}
             </div>
           </div>
@@ -180,14 +172,15 @@ export default function MindsetPage() {
                 <span className="text-white font-bold">LS</span>
               </div>
               <div>
-                <h2 className="text-2xl font-bold text-white">Conseils terrain Laurent Serre</h2>
-                <p className="text-orange-300">20 ans d'expérience en développement commercial PME</p>
+                <h2 className="text-2xl font-bold text-primary-title">Conseils terrain Laurent Serre</h2>
+                <p className="text-primary-secondary">20 ans d'expérience en développement commercial PME</p>
               </div>
             </div>
             <div className="bg-white/10 rounded-lg p-6 border border-orange-soft/20">
-              <p className="text-white/90 leading-relaxed whitespace-pre-line">
-                {bookData.terrainAdvice}
-              </p>
+              <MarkdownRenderer 
+                content={bookData.terrainAdvice} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -197,7 +190,7 @@ export default function MindsetPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={400}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-orange-soft">👥</span>
               Pour qui ce livre ?
             </h2>
@@ -205,10 +198,10 @@ export default function MindsetPage() {
               {Array.isArray(bookData.targetProfiles) && bookData.targetProfiles.length > 0 ? bookData.targetProfiles.map((profile, index) => (
                 <div key={index} className="flex items-center gap-3 p-4 bg-white/5 rounded-lg border border-orange-soft/10">
                   <span className="text-orange-soft">✓</span>
-                  <span className="text-white/90">{profile}</span>
+                  <span className="text-primary-secondary">{profile}</span>
                 </div>
               )) : (
-                <p className="text-white/70">Profils cibles en cours de définition...</p>
+                <p className="text-primary-secondary/70">Profils cibles en cours de définition...</p>
               )}
             </div>
           </div>
@@ -219,11 +212,11 @@ export default function MindsetPage() {
       <section className="max-w-6xl mx-auto mb-12 px-4">
         <AnimatedSection delay={500}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-orange-soft/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-orange-soft">📚</span>
               Livres complémentaires recommandés
             </h2>
-            <p className="text-white/80 mb-4">
+            <p className="text-primary-secondary mb-4">
               Pour approfondir votre développement personnel et commercial, découvrez ces autres références essentielles.
             </p>
             <div className="flex flex-wrap gap-2">

--- a/src/app/ressources/meilleurs-livres/mindset-performance/mindset/page.tsx
+++ b/src/app/ressources/meilleurs-livres/mindset-performance/mindset/page.tsx
@@ -5,6 +5,7 @@ import AnimatedSection from '@/components/ui/AnimatedSection';
 import BookCard from '@/components/ui/BookCard';
 import CategoryBreadcrumb from '@/components/ui/CategoryBreadcrumb';
 import ParticleBackground from '@/components/ui/ParticleBackground';
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer';
 import { categoryBreadcrumbSuggestions } from '@/utils/cross-category-suggestions';
 import React from 'react';
 
@@ -74,25 +75,25 @@ export default function MindsetPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection animation="fade-in" delay={0}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-emerald-500/20">
-            <div className="flex flex-col lg:flex-row gap-8 items-start">
+            <div className="flex flex-col gap-8 items-start">
               {/* Informations du livre */}
-              <div className="flex-1">
+              <div className="w-full">
                 <div className="flex items-center gap-2 mb-4">
                   <span className="bg-emerald-500/20 text-emerald-400 px-3 py-1 rounded-full text-sm font-medium">
                     🧠 Mindset & Performance
                   </span>
-                  <span className="bg-white/20 text-white px-3 py-1 rounded-full text-sm">
+                  <span className="bg-white/20 text-primary-secondary px-3 py-1 rounded-full text-sm">
                     {bookData.year}
                   </span>
                 </div>
                 
-                <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">
+                <h1 className="text-3xl md:text-4xl font-bold text-primary-title mb-2">
                   {bookData.title}
                 </h1>
-                <p className="text-xl text-emerald-300 mb-4">
+                <p className="text-xl text-primary-secondary mb-4">
                   par {bookData.author}
                 </p>
-                <p className="text-lg text-white/80 mb-6 leading-relaxed">
+                <p className="text-lg text-primary-secondary/90 mb-6 leading-relaxed">
                   {bookData.tagline}
                 </p>
                 
@@ -100,33 +101,23 @@ export default function MindsetPage() {
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
                   <div className="text-center">
                     <div className="text-2xl font-bold text-emerald-400">{bookData.rating}/5</div>
-                    <div className="text-xs text-white/70">Note Laurent Serre</div>
+                    <div className="text-xs text-primary-secondary">Note Laurent Serre</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-emerald-400">{bookData.difficulty}</div>
-                    <div className="text-xs text-white/70">Difficulté</div>
+                    <div className="text-xs text-primary-secondary">Difficulté</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-emerald-400">{bookData.readingTime}</div>
-                    <div className="text-xs text-white/70">Lecture</div>
+                    <div className="text-xs text-primary-secondary">Lecture</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-emerald-400">★★★</div>
-                    <div className="text-xs text-white/70">Impact commercial</div>
+                    <div className="text-xs text-primary-secondary">Impact commercial</div>
                   </div>
                 </div>
               </div>
-              
-              {/* BookCard en version featured */}
-              <div className="lg:w-80">
-                <BookCard 
-                  book={bookData} 
-                  variant="featured"
-                  showRating={true}
-                  showDifficulty={true}
-                  showReadingTime={true}
-                />
-              </div>
+
             </div>
           </div>
         </AnimatedSection>
@@ -136,14 +127,15 @@ export default function MindsetPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={100}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-emerald-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-emerald-400">📖</span>
               Résumé détaillé
             </h2>
-            <div className="prose prose-lg prose-invert max-w-none">
-              <p className="text-white/90 leading-relaxed mb-6">
-                {bookData.detailedSummary}
-              </p>
+            <div className="prose prose-lg max-w-none">
+              <MarkdownRenderer 
+                content={bookData.detailedSummary} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -153,7 +145,7 @@ export default function MindsetPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={200}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-emerald-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-emerald-400">🎯</span>
               Points clés à retenir
             </h2>
@@ -161,10 +153,10 @@ export default function MindsetPage() {
               {Array.isArray(bookData.keyPoints) && bookData.keyPoints.length > 0 ? bookData.keyPoints.map((point, index) => (
                 <div key={index} className="flex items-start gap-3 p-4 bg-white/5 rounded-lg border border-emerald-500/10">
                   <span className="text-emerald-400 font-bold text-lg">{index + 1}.</span>
-                  <p className="text-white/90 leading-relaxed">{point}</p>
+                  <p className="text-primary-secondary leading-relaxed">{point}</p>
                 </div>
               )) : (
-                <p className="text-white/70">Points clés en cours de rédaction...</p>
+                <p className="text-primary-secondary/70">Points clés en cours de rédaction...</p>
               )}
             </div>
           </div>
@@ -180,14 +172,15 @@ export default function MindsetPage() {
                 <span className="text-white font-bold">LS</span>
               </div>
               <div>
-                <h2 className="text-2xl font-bold text-white">Conseils terrain Laurent Serre</h2>
-                <p className="text-emerald-300">20 ans d'expérience en développement commercial PME</p>
+                <h2 className="text-2xl font-bold text-primary-title">Conseils terrain Laurent Serre</h2>
+                <p className="text-primary-secondary">20 ans d'expérience en développement commercial PME</p>
               </div>
             </div>
             <div className="bg-white/10 rounded-lg p-6 border border-emerald-500/20">
-              <p className="text-white/90 leading-relaxed whitespace-pre-line">
-                {bookData.terrainAdvice}
-              </p>
+              <MarkdownRenderer 
+                content={bookData.terrainAdvice} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -197,7 +190,7 @@ export default function MindsetPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={400}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-emerald-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-emerald-400">👥</span>
               Pour qui ce livre ?
             </h2>
@@ -205,10 +198,10 @@ export default function MindsetPage() {
               {Array.isArray(bookData.targetProfiles) && bookData.targetProfiles.length > 0 ? bookData.targetProfiles.map((profile, index) => (
                 <div key={index} className="flex items-center gap-3 p-4 bg-white/5 rounded-lg border border-emerald-500/10">
                   <span className="text-emerald-400">✓</span>
-                  <span className="text-white/90">{profile}</span>
+                  <span className="text-primary-secondary">{profile}</span>
                 </div>
               )) : (
-                <p className="text-white/70">Profils cibles en cours de définition...</p>
+                <p className="text-primary-secondary/70">Profils cibles en cours de définition...</p>
               )}
             </div>
           </div>
@@ -219,11 +212,11 @@ export default function MindsetPage() {
       <section className="max-w-6xl mx-auto mb-12 px-4">
         <AnimatedSection delay={500}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-emerald-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-emerald-400">📚</span>
               Livres complémentaires recommandés
             </h2>
-            <p className="text-white/80 mb-4">
+            <p className="text-primary-secondary mb-4">
               Pour approfondir votre développement du mindset et de la performance commerciale.
             </p>
             <div className="flex flex-wrap gap-2">

--- a/src/app/ressources/meilleurs-livres/mindset-performance/peak-performance/page.tsx
+++ b/src/app/ressources/meilleurs-livres/mindset-performance/peak-performance/page.tsx
@@ -5,6 +5,7 @@ import AnimatedSection from '@/components/ui/AnimatedSection';
 import BookCard from '@/components/ui/BookCard';
 import CategoryBreadcrumb from '@/components/ui/CategoryBreadcrumb';
 import ParticleBackground from '@/components/ui/ParticleBackground';
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer';
 import { categoryBreadcrumbSuggestions } from '@/utils/cross-category-suggestions';
 import React from 'react';
 
@@ -78,25 +79,25 @@ export default function PeakPerformancePage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection animation="fade-in" delay={0}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-purple-500/20">
-            <div className="flex flex-col lg:flex-row gap-8 items-start">
+            <div className="flex flex-col gap-8 items-start">
               {/* Informations du livre */}
-              <div className="flex-1">
+              <div className="w-full">
                 <div className="flex items-center gap-2 mb-4">
                   <span className="bg-purple-500/20 text-purple-400 px-3 py-1 rounded-full text-sm font-medium">
                     🧠 Mindset & Performance
                   </span>
-                  <span className="bg-white/20 text-white px-3 py-1 rounded-full text-sm">
+                  <span className="bg-white/20 text-primary-secondary px-3 py-1 rounded-full text-sm">
                     {bookData.year}
                   </span>
                 </div>
                 
-                <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">
+                <h1 className="text-3xl md:text-4xl font-bold text-primary-title mb-2">
                   {bookData.title}
                 </h1>
-                <p className="text-xl text-purple-300 mb-4">
+                <p className="text-xl text-primary-secondary mb-4">
                   par {bookData.author}
                 </p>
-                <p className="text-lg text-white/80 mb-6 leading-relaxed">
+                <p className="text-lg text-primary-secondary/90 mb-6 leading-relaxed">
                   {bookData.tagline}
                 </p>
                 
@@ -104,33 +105,24 @@ export default function PeakPerformancePage() {
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
                   <div className="text-center">
                     <div className="text-2xl font-bold text-purple-400">{bookData.rating}/5</div>
-                    <div className="text-xs text-white/70">Note Laurent Serre</div>
+                    <div className="text-xs text-primary-secondary">Note Laurent Serre</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-purple-400">{bookData.difficulty}</div>
-                    <div className="text-xs text-white/70">Difficulté</div>
+                    <div className="text-xs text-primary-secondary">Difficulté</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-purple-400">{bookData.readingTime}</div>
-                    <div className="text-xs text-white/70">Lecture</div>
+                    <div className="text-xs text-primary-secondary">Lecture</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-purple-400">★★★</div>
-                    <div className="text-xs text-white/70">Impact commercial</div>
+                    <div className="text-xs text-primary-secondary">Impact commercial</div>
                   </div>
                 </div>
               </div>
               
-              {/* BookCard en version featured */}
-              <div className="lg:w-80">
-                <BookCard 
-                  book={bookData} 
-                  variant="featured"
-                  showRating={true}
-                  showDifficulty={true}
-                  showReadingTime={true}
-                />
-              </div>
+
             </div>
           </div>
         </AnimatedSection>
@@ -140,14 +132,15 @@ export default function PeakPerformancePage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={100}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-purple-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-purple-400">📖</span>
               Résumé détaillé
             </h2>
-            <div className="prose prose-lg prose-invert max-w-none">
-              <p className="text-white/90 leading-relaxed mb-6">
-                {bookData.detailedSummary}
-              </p>
+            <div className="prose prose-lg max-w-none">
+              <MarkdownRenderer 
+                content={bookData.detailedSummary} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -157,7 +150,7 @@ export default function PeakPerformancePage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={200}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-purple-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-purple-400">🎯</span>
               Points clés à retenir
             </h2>
@@ -165,10 +158,10 @@ export default function PeakPerformancePage() {
               {Array.isArray(bookData.keyPoints) && bookData.keyPoints.length > 0 ? bookData.keyPoints.map((point, index) => (
                 <div key={index} className="flex items-start gap-3 p-4 bg-white/5 rounded-lg border border-purple-500/10">
                   <span className="text-purple-400 font-bold text-lg">{index + 1}.</span>
-                  <p className="text-white/90 leading-relaxed">{point}</p>
+                  <p className="text-primary-secondary leading-relaxed">{point}</p>
                 </div>
               )) : (
-                <p className="text-white/70">Points clés en cours de rédaction...</p>
+                <p className="text-primary-secondary/70">Points clés en cours de rédaction...</p>
               )}
             </div>
           </div>
@@ -184,14 +177,15 @@ export default function PeakPerformancePage() {
                 <span className="text-white font-bold">LS</span>
               </div>
               <div>
-                <h2 className="text-2xl font-bold text-white">Conseils terrain Laurent Serre</h2>
-                <p className="text-purple-300">20 ans d'expérience en développement commercial PME</p>
+                <h2 className="text-2xl font-bold text-primary-title">Conseils terrain Laurent Serre</h2>
+                <p className="text-primary-secondary">20 ans d'expérience en développement commercial PME</p>
               </div>
             </div>
             <div className="bg-white/10 rounded-lg p-6 border border-purple-500/20">
-              <p className="text-white/90 leading-relaxed whitespace-pre-line">
-                {bookData.terrainAdvice}
-              </p>
+              <MarkdownRenderer 
+                content={bookData.terrainAdvice} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -201,7 +195,7 @@ export default function PeakPerformancePage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={400}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-purple-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-purple-400">👥</span>
               Pour qui ce livre ?
             </h2>
@@ -209,10 +203,10 @@ export default function PeakPerformancePage() {
               {Array.isArray(bookData.targetProfiles) && bookData.targetProfiles.length > 0 ? bookData.targetProfiles.map((profile, index) => (
                 <div key={index} className="flex items-center gap-3 p-4 bg-white/5 rounded-lg border border-purple-500/10">
                   <span className="text-purple-400">✓</span>
-                  <span className="text-white/90">{profile}</span>
+                  <span className="text-primary-secondary">{profile}</span>
                 </div>
               )) : (
-                <p className="text-white/70">Profils cibles en cours de définition...</p>
+                <p className="text-primary-secondary/70">Profils cibles en cours de définition...</p>
               )}
             </div>
           </div>
@@ -223,11 +217,11 @@ export default function PeakPerformancePage() {
       <section className="max-w-6xl mx-auto mb-12 px-4">
         <AnimatedSection delay={500}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-purple-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-purple-400">📚</span>
               Livres complémentaires recommandés
             </h2>
-            <p className="text-white/80 mb-4">
+            <p className="text-primary-secondary mb-4">
               Pour approfondir votre approche scientifique de la performance commerciale.
             </p>
             <div className="flex flex-wrap gap-2">

--- a/src/app/ressources/meilleurs-livres/mindset-performance/the-7-habits/page.tsx
+++ b/src/app/ressources/meilleurs-livres/mindset-performance/the-7-habits/page.tsx
@@ -5,6 +5,7 @@ import AnimatedSection from '@/components/ui/AnimatedSection';
 import BookCard from '@/components/ui/BookCard';
 import CategoryBreadcrumb from '@/components/ui/CategoryBreadcrumb';
 import ParticleBackground from '@/components/ui/ParticleBackground';
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer';
 import { categoryBreadcrumbSuggestions } from '@/utils/cross-category-suggestions';
 import React from 'react';
 
@@ -74,25 +75,25 @@ export default function The7HabitsPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection animation="fade-in" delay={0}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-blue-500/20">
-            <div className="flex flex-col lg:flex-row gap-8 items-start">
+            <div className="flex flex-col gap-8 items-start">
               {/* Informations du livre */}
-              <div className="flex-1">
+              <div className="w-full">
                 <div className="flex items-center gap-2 mb-4">
                   <span className="bg-blue-500/20 text-blue-400 px-3 py-1 rounded-full text-sm font-medium">
                     🧠 Mindset & Performance
                   </span>
-                  <span className="bg-white/20 text-white px-3 py-1 rounded-full text-sm">
+                  <span className="bg-white/20 text-primary-secondary px-3 py-1 rounded-full text-sm">
                     {bookData.year}
                   </span>
                 </div>
                 
-                <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">
+                <h1 className="text-3xl md:text-4xl font-bold text-primary-title mb-2">
                   {bookData.title}
                 </h1>
-                <p className="text-xl text-blue-300 mb-4">
+                <p className="text-xl text-primary-secondary mb-4">
                   par {bookData.author}
                 </p>
-                <p className="text-lg text-white/80 mb-6 leading-relaxed">
+                <p className="text-lg text-primary-secondary/90 mb-6 leading-relaxed">
                   {bookData.tagline}
                 </p>
                 
@@ -100,33 +101,24 @@ export default function The7HabitsPage() {
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
                   <div className="text-center">
                     <div className="text-2xl font-bold text-blue-400">{bookData.rating}/5</div>
-                    <div className="text-xs text-white/70">Note Laurent Serre</div>
+                    <div className="text-xs text-primary-secondary">Note Laurent Serre</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-blue-400">{bookData.difficulty}</div>
-                    <div className="text-xs text-white/70">Difficulté</div>
+                    <div className="text-xs text-primary-secondary">Difficulté</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-blue-400">{bookData.readingTime}</div>
-                    <div className="text-xs text-white/70">Lecture</div>
+                    <div className="text-xs text-primary-secondary">Lecture</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-blue-400">★★★</div>
-                    <div className="text-xs text-white/70">Impact commercial</div>
+                    <div className="text-xs text-primary-secondary">Impact commercial</div>
                   </div>
                 </div>
               </div>
               
-              {/* BookCard en version featured */}
-              <div className="lg:w-80">
-                <BookCard 
-                  book={bookData} 
-                  variant="featured"
-                  showRating={true}
-                  showDifficulty={true}
-                  showReadingTime={true}
-                />
-              </div>
+
             </div>
           </div>
         </AnimatedSection>
@@ -136,14 +128,15 @@ export default function The7HabitsPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={100}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-blue-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-blue-400">📖</span>
               Résumé détaillé
             </h2>
-            <div className="prose prose-lg prose-invert max-w-none">
-              <p className="text-white/90 leading-relaxed mb-6">
-                {bookData.detailedSummary}
-              </p>
+            <div className="prose prose-lg max-w-none">
+              <MarkdownRenderer 
+                content={bookData.detailedSummary} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -153,7 +146,7 @@ export default function The7HabitsPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={200}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-blue-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-blue-400">🎯</span>
               Points clés à retenir
             </h2>
@@ -161,10 +154,10 @@ export default function The7HabitsPage() {
               {Array.isArray(bookData.keyPoints) && bookData.keyPoints.length > 0 ? bookData.keyPoints.map((point, index) => (
                 <div key={index} className="flex items-start gap-3 p-4 bg-white/5 rounded-lg border border-blue-500/10">
                   <span className="text-blue-400 font-bold text-lg">{index + 1}.</span>
-                  <p className="text-white/90 leading-relaxed">{point}</p>
+                  <p className="text-primary-secondary leading-relaxed">{point}</p>
                 </div>
               )) : (
-                <p className="text-white/70">Points clés en cours de rédaction...</p>
+                <p className="text-primary-secondary/70">Points clés en cours de rédaction...</p>
               )}
             </div>
           </div>
@@ -180,14 +173,15 @@ export default function The7HabitsPage() {
                 <span className="text-white font-bold">LS</span>
               </div>
               <div>
-                <h2 className="text-2xl font-bold text-white">Conseils terrain Laurent Serre</h2>
-                <p className="text-blue-300">20 ans d'expérience en développement commercial PME</p>
+                <h2 className="text-2xl font-bold text-primary-title">Conseils terrain Laurent Serre</h2>
+                <p className="text-primary-secondary">20 ans d'expérience en développement commercial PME</p>
               </div>
             </div>
             <div className="bg-white/10 rounded-lg p-6 border border-blue-500/20">
-              <p className="text-white/90 leading-relaxed whitespace-pre-line">
-                {bookData.terrainAdvice}
-              </p>
+              <MarkdownRenderer 
+                content={bookData.terrainAdvice} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -197,7 +191,7 @@ export default function The7HabitsPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={400}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-blue-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-blue-400">👥</span>
               Pour qui ce livre ?
             </h2>
@@ -205,10 +199,10 @@ export default function The7HabitsPage() {
               {Array.isArray(bookData.targetProfiles) && bookData.targetProfiles.length > 0 ? bookData.targetProfiles.map((profile, index) => (
                 <div key={index} className="flex items-center gap-3 p-4 bg-white/5 rounded-lg border border-blue-500/10">
                   <span className="text-blue-400">✓</span>
-                  <span className="text-white/90">{profile}</span>
+                  <span className="text-primary-secondary">{profile}</span>
                 </div>
               )) : (
-                <p className="text-white/70">Profils cibles en cours de définition...</p>
+                <p className="text-primary-secondary/70">Profils cibles en cours de définition...</p>
               )}
             </div>
           </div>
@@ -219,11 +213,11 @@ export default function The7HabitsPage() {
       <section className="max-w-6xl mx-auto mb-12 px-4">
         <AnimatedSection delay={500}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-blue-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-blue-400">📚</span>
               Livres complémentaires recommandés
             </h2>
-            <p className="text-white/80 mb-4">
+            <p className="text-primary-secondary mb-4">
               Pour approfondir votre développement personnel et votre leadership commercial.
             </p>
             <div className="flex flex-wrap gap-2">

--- a/src/app/ressources/meilleurs-livres/mindset-performance/the-power-of-now/page.tsx
+++ b/src/app/ressources/meilleurs-livres/mindset-performance/the-power-of-now/page.tsx
@@ -5,6 +5,7 @@ import AnimatedSection from '@/components/ui/AnimatedSection';
 import BookCard from '@/components/ui/BookCard';
 import CategoryBreadcrumb from '@/components/ui/CategoryBreadcrumb';
 import ParticleBackground from '@/components/ui/ParticleBackground';
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer';
 import { categoryBreadcrumbSuggestions } from '@/utils/cross-category-suggestions';
 import React from 'react';
 
@@ -78,25 +79,25 @@ export default function ThePowerOfNowPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection animation="fade-in" delay={0}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-green-500/20">
-            <div className="flex flex-col lg:flex-row gap-8 items-start">
+            <div className="flex flex-col gap-8 items-start">
               {/* Informations du livre */}
-              <div className="flex-1">
+              <div className="w-full">
                 <div className="flex items-center gap-2 mb-4">
                   <span className="bg-green-500/20 text-green-400 px-3 py-1 rounded-full text-sm font-medium">
                     🧠 Mindset & Performance
                   </span>
-                  <span className="bg-white/20 text-white px-3 py-1 rounded-full text-sm">
+                  <span className="bg-white/20 text-primary-secondary px-3 py-1 rounded-full text-sm">
                     {bookData.year}
                   </span>
                 </div>
                 
-                <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">
+                <h1 className="text-3xl md:text-4xl font-bold text-primary-title mb-2">
                   {bookData.title}
                 </h1>
-                <p className="text-xl text-green-300 mb-4">
+                <p className="text-xl text-primary-secondary mb-4">
                   par {bookData.author}
                 </p>
-                <p className="text-lg text-white/80 mb-6 leading-relaxed">
+                <p className="text-lg text-primary-secondary/90 mb-6 leading-relaxed">
                   {bookData.tagline}
                 </p>
                 
@@ -104,33 +105,23 @@ export default function ThePowerOfNowPage() {
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
                   <div className="text-center">
                     <div className="text-2xl font-bold text-green-400">{bookData.rating}/5</div>
-                    <div className="text-xs text-white/70">Note Laurent Serre</div>
+                    <div className="text-xs text-primary-secondary">Note Laurent Serre</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-green-400">{bookData.difficulty}</div>
-                    <div className="text-xs text-white/70">Difficulté</div>
+                    <div className="text-xs text-primary-secondary">Difficulté</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-green-400">{bookData.readingTime}</div>
-                    <div className="text-xs text-white/70">Lecture</div>
+                    <div className="text-xs text-primary-secondary">Lecture</div>
                   </div>
                   <div className="text-center">
                     <div className="text-2xl font-bold text-green-400">★★☆</div>
-                    <div className="text-xs text-white/70">Impact commercial</div>
+                    <div className="text-xs text-primary-secondary">Impact commercial</div>
                   </div>
                 </div>
               </div>
-              
-              {/* BookCard en version featured */}
-              <div className="lg:w-80">
-                <BookCard 
-                  book={bookData} 
-                  variant="featured"
-                  showRating={true}
-                  showDifficulty={true}
-                  showReadingTime={true}
-                />
-              </div>
+
             </div>
           </div>
         </AnimatedSection>
@@ -140,14 +131,15 @@ export default function ThePowerOfNowPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={100}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-green-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-green-400">📖</span>
               Résumé détaillé
             </h2>
-            <div className="prose prose-lg prose-invert max-w-none">
-              <p className="text-white/90 leading-relaxed mb-6">
-                {bookData.detailedSummary}
-              </p>
+            <div className="prose prose-lg max-w-none">
+              <MarkdownRenderer 
+                content={bookData.detailedSummary} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -157,7 +149,7 @@ export default function ThePowerOfNowPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={200}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-green-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-green-400">🎯</span>
               Points clés à retenir
             </h2>
@@ -165,10 +157,10 @@ export default function ThePowerOfNowPage() {
               {Array.isArray(bookData.keyPoints) && bookData.keyPoints.length > 0 ? bookData.keyPoints.map((point, index) => (
                 <div key={index} className="flex items-start gap-3 p-4 bg-white/5 rounded-lg border border-green-500/10">
                   <span className="text-green-400 font-bold text-lg">{index + 1}.</span>
-                  <p className="text-white/90 leading-relaxed">{point}</p>
+                  <p className="text-primary-secondary leading-relaxed">{point}</p>
                 </div>
               )) : (
-                <p className="text-white/70">Points clés en cours de rédaction...</p>
+                <p className="text-primary-secondary/70">Points clés en cours de rédaction...</p>
               )}
             </div>
           </div>
@@ -184,14 +176,15 @@ export default function ThePowerOfNowPage() {
                 <span className="text-white font-bold">LS</span>
               </div>
               <div>
-                <h2 className="text-2xl font-bold text-white">Conseils terrain Laurent Serre</h2>
-                <p className="text-green-300">20 ans d'expérience en développement commercial PME</p>
+                <h2 className="text-2xl font-bold text-primary-title">Conseils terrain Laurent Serre</h2>
+                <p className="text-primary-secondary">20 ans d'expérience en développement commercial PME</p>
               </div>
             </div>
             <div className="bg-white/10 rounded-lg p-6 border border-green-500/20">
-              <p className="text-white/90 leading-relaxed whitespace-pre-line">
-                {bookData.terrainAdvice}
-              </p>
+              <MarkdownRenderer 
+                content={bookData.terrainAdvice} 
+                className="text-primary-secondary"
+              />
             </div>
           </div>
         </AnimatedSection>
@@ -201,7 +194,7 @@ export default function ThePowerOfNowPage() {
       <section className="max-w-4xl mx-auto mb-12 px-4">
         <AnimatedSection delay={400}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-green-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-green-400">👥</span>
               Pour qui ce livre ?
             </h2>
@@ -209,10 +202,10 @@ export default function ThePowerOfNowPage() {
               {Array.isArray(bookData.targetProfiles) && bookData.targetProfiles.length > 0 ? bookData.targetProfiles.map((profile, index) => (
                 <div key={index} className="flex items-center gap-3 p-4 bg-white/5 rounded-lg border border-green-500/10">
                   <span className="text-green-400">✓</span>
-                  <span className="text-white/90">{profile}</span>
+                  <span className="text-primary-secondary">{profile}</span>
                 </div>
               )) : (
-                <p className="text-white/70">Profils cibles en cours de définition...</p>
+                <p className="text-primary-secondary/70">Profils cibles en cours de définition...</p>
               )}
             </div>
           </div>
@@ -223,11 +216,11 @@ export default function ThePowerOfNowPage() {
       <section className="max-w-6xl mx-auto mb-12 px-4">
         <AnimatedSection delay={500}>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-green-500/20">
-            <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-primary-title mb-6 flex items-center gap-3">
               <span className="text-green-400">📚</span>
               Livres complémentaires recommandés
             </h2>
-            <p className="text-white/80 mb-4">
+            <p className="text-primary-secondary mb-4">
               Pour approfondir votre développement spirituel et votre présence authentique.
             </p>
             <div className="flex flex-wrap gap-2">

--- a/src/app/ressources/meilleurs-livres/sales-management/good-to-great/page.tsx
+++ b/src/app/ressources/meilleurs-livres/sales-management/good-to-great/page.tsx
@@ -118,13 +118,13 @@ export default function GoodToGreatPage() {
             <span className="inline-block bg-mint-green/20 text-mint-green font-semibold rounded-full px-4 py-2 text-sm shadow-md backdrop-blur mb-2">
               Sales Management & Leadership
             </span>
-            <h1 className="text-4xl md:text-6xl font-bold text-white mb-4 drop-shadow-lg">
+            <h1 className="text-4xl md:text-6xl font-bold text-primary-title mb-4 drop-shadow-lg">
               Good to Great
             </h1>
-            <p className="text-xl text-mint-green font-semibold mb-2">
-              Jim Collins <span className="text-white/60 font-normal">— 2001</span>
+            <p className="text-xl text-primary-secondary font-semibold mb-2">
+              Jim Collins <span className="text-primary-secondary/70 font-normal">— 2001</span>
             </p>
-            <p className="text-lg text-white/90 italic mb-6 max-w-2xl mx-auto">
+            <p className="text-lg text-primary-secondary/90 italic mb-6 max-w-2xl mx-auto">
               Les facteurs durables de la réussite organisationnelle
             </p>
             
@@ -133,7 +133,7 @@ export default function GoodToGreatPage() {
               <span className="bg-orange-soft/20 text-orange-soft px-3 py-1 rounded-full text-sm font-medium">
                 Intermédiaire
               </span>
-              <span className="bg-blue-ink/20 text-white px-3 py-1 rounded-full text-sm font-medium">
+              <span className="bg-blue-ink/20 text-primary-secondary px-3 py-1 rounded-full text-sm font-medium">
                 8h de lecture
               </span>
               <div className="flex items-center bg-yellow-400/20 text-yellow-600 px-3 py-1 rounded-full text-sm font-medium">

--- a/src/components/ui/MarkdownRenderer.tsx
+++ b/src/components/ui/MarkdownRenderer.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+interface MarkdownRendererProps {
+  content: string;
+  className?: string;
+}
+
+export default function MarkdownRenderer({ content, className = "" }: MarkdownRendererProps) {
+  // Fonction pour traiter le contenu Markdown
+  const processMarkdown = (text: string): JSX.Element[] => {
+    // Diviser le texte en paragraphes
+    const paragraphs = text.split('\n\n').filter(p => p.trim());
+    
+    return paragraphs.map((paragraph, index) => {
+      // Traiter le texte gras **texte**
+      const processedText = paragraph.split(/(\*\*[^*]+\*\*)/).map((part, partIndex) => {
+        if (part.startsWith('**') && part.endsWith('**')) {
+          const boldText = part.slice(2, -2);
+          return <strong key={partIndex} className="font-semibold text-primary-title">{boldText}</strong>;
+        }
+        
+        // Traiter les sauts de ligne simples \n
+        const lines = part.split('\n');
+        return lines.map((line, lineIndex) => (
+          <React.Fragment key={`${partIndex}-${lineIndex}`}>
+            {line}
+            {lineIndex < lines.length - 1 && <br />}
+          </React.Fragment>
+        ));
+      });
+      
+      return (
+        <p key={index} className="mb-4 leading-relaxed">
+          {processedText}
+        </p>
+      );
+    });
+  };
+
+  return (
+    <div className={className}>
+      {processMarkdown(content)}
+    </div>
+  );
+}

--- a/src/utils/fix-markdown-pages.ts
+++ b/src/utils/fix-markdown-pages.ts
@@ -1,0 +1,43 @@
+// Script pour corriger le rendu Markdown sur toutes les pages de livres
+// Ce script identifie les patterns à corriger et génère les remplacements nécessaires
+
+export const markdownFixes = [
+  // Import du composant MarkdownRenderer
+  {
+    search: /import React from 'react';$/m,
+    replace: `import React from 'react';
+import MarkdownRenderer from '@/components/ui/MarkdownRenderer';`
+  },
+  
+  // Correction du résumé détaillé
+  {
+    search: /<div className="prose prose-lg (?:prose-invert )?max-w-none">\s*<p className="text-(?:white\/90|primary-secondary) leading-relaxed mb-6">\s*\{bookData\.detailedSummary\}\s*<\/p>\s*<\/div>/gs,
+    replace: `<div className="prose prose-lg max-w-none">
+              <MarkdownRenderer 
+                content={bookData.detailedSummary} 
+                className="text-primary-secondary"
+              />
+            </div>`
+  },
+  
+  // Correction des conseils terrain
+  {
+    search: /<p className="text-(?:white\/90|primary-secondary) leading-relaxed whitespace-pre-line">\s*\{bookData\.terrainAdvice\}\s*<\/p>/gs,
+    replace: `<MarkdownRenderer 
+                content={bookData.terrainAdvice} 
+                className="text-primary-secondary"
+              />`
+  }
+];
+
+export const filesToFix = [
+  'src/app/ressources/meilleurs-livres/mindset-performance/7-habitudes-gens-efficaces/page.tsx',
+  'src/app/ressources/meilleurs-livres/mindset-performance/mindset-new-psychology-success/page.tsx',
+  'src/app/ressources/meilleurs-livres/mindset-performance/grit-power-passion-perseverance/page.tsx',
+  'src/app/ressources/meilleurs-livres/mindset-performance/the-power-of-now/page.tsx',
+  'src/app/ressources/meilleurs-livres/mindset-performance/cant-hurt-me/page.tsx',
+  'src/app/ressources/meilleurs-livres/mindset-performance/peak-performance/page.tsx',
+  'src/app/ressources/meilleurs-livres/mindset-performance/mindset/page.tsx',
+  'src/app/ressources/meilleurs-livres/mindset-performance/the-7-habits/page.tsx',
+  // Ajouter d'autres pages si nécessaire
+];


### PR DESCRIPTION
- Section Mindset & Performance (9/9 pages) :
  * Remplacement du texte blanc par text-primary-title/text-primary-secondary
  * Correction des métadonnées (notes, difficulté, temps de lecture)
  * Suppression des cartes de livre redondantes dans les sections hero
  * Implémentation du composant MarkdownRenderer pour le rendu correct du Markdown

- Section Digital & AI Sales :
  * Correction de la page principale avec texte lisible
  * Correction partielle de la page AI Superpowers

- Section Sales Management & Leadership :
  * Correction de la page Good to Great

- Création du composant MarkdownRenderer pour traiter le Markdown (gras, paragraphes, sauts de ligne)

Toutes les pages de la section Mindset & Performance sont maintenant parfaitement lisibles et fonctionnelles.